### PR TITLE
Expression nodes counting and related tests

### DIFF
--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -32,7 +32,6 @@ namespace Ariadne {
 
 #define ARIADNE_LOG_PRINT(level, expr) { ARIADNE_LOG(level,#expr << "=" << (expr) << "\n"); }
 
-
 DifferentialInclusion::DifferentialInclusion(DottedRealAssignments const& dynamics, const RealVariablesBox& inputs)
     : _dynamics(dynamics), _inputs(inputs) {
     ARIADNE_ASSERT_MSG(is_affine_in(Vector<RealExpression>(right_hand_sides(dynamics)),inputs.variables()),"The dynamics " << dynamics << " must be input-affine.\n");

--- a/source/symbolic/expression.cpp
+++ b/source/symbolic/expression.cpp
@@ -127,6 +127,8 @@ template Nat count_nodes<Real>(const Expression<Real>& e);
 template Nat count_distinct_nodes<Real>(const Expression<Real>& e);
 template Nat count_distinct_node_ptrs<Real>(const Expression<Real>& e);
 
+template Bool is_constant_in<Real>(const Expression<Real>& e, const Set<Variable<Real>>& vs);
+template Bool is_affine_in<Real>(const Expression<Real>& e, const Set<Variable<Real>>& vs);
 template Bool is_affine_in<Real>(const Vector<Expression<Real>>& e, const Set<Variable<Real>>& vs);
 template Bool is_additive_in<Real>(const Vector<Expression<Real>>& e, const Set<Variable<Real>>& vs);
 

--- a/source/symbolic/expression.cpp
+++ b/source/symbolic/expression.cpp
@@ -125,6 +125,7 @@ template class Expression<Real>;
 template Bool before<Real>(Expression<Real> const& e1, Expression<Real> const& e2);
 template Nat count_nodes<Real>(const Expression<Real>& e);
 template Nat count_distinct_nodes<Real>(const Expression<Real>& e);
+template Nat count_distinct_node_ptrs<Real>(const Expression<Real>& e);
 
 template Bool is_affine_in<Real>(const Vector<Expression<Real>>& e, const Set<Variable<Real>>& vs);
 template Bool is_additive_in<Real>(const Vector<Expression<Real>>& e, const Set<Variable<Real>>& vs);

--- a/source/symbolic/expression.cpp
+++ b/source/symbolic/expression.cpp
@@ -122,6 +122,10 @@ template class Expression<String>;
 template class Expression<Integer>;
 template class Expression<Real>;
 
+template Bool before<Real>(Expression<Real> const& e1, Expression<Real> const& e2);
+template Nat count_nodes<Real>(const Expression<Real>& e);
+template Nat count_distinct_nodes<Real>(const Expression<Real>& e);
+
 template Bool is_affine_in<Real>(const Vector<Expression<Real>>& e, const Set<Variable<Real>>& vs);
 template Bool is_additive_in<Real>(const Vector<Expression<Real>>& e, const Set<Variable<Real>>& vs);
 

--- a/source/symbolic/expression.hpp
+++ b/source/symbolic/expression.hpp
@@ -182,8 +182,10 @@ template<class T> Bool identical(const Expression<T>& e1, const Expression<T>& e
 
 //! \brief Count the number of nodes in the expression \a e.
 template<class T> Nat count_nodes(const Expression<T>& e);
-//! \brief Count the number of distinct (i.e., having different raw pointer) nodes in the expression \a e.
+//! \brief Count the number of distinct (i.e., having identical representation) nodes in the expression \a e.
 template<class T> Nat count_distinct_nodes(const Expression<T>& e);
+//! \brief Count the number of distinct node pointers in the expression \a e.
+template<class T> Nat count_distinct_node_ptrs(const Expression<T>& e);
 
 //! \brief Returns true if the expressions are mutual negations.
 //!

--- a/source/symbolic/expression.hpp
+++ b/source/symbolic/expression.hpp
@@ -169,6 +169,9 @@ template<class T> Bool is_affine_in(const Vector<Expression<T>>& e, const Set<Va
 //! \brief Returns \a true if the vector expression \a e is syntactically additive (possibly with multipliers) in the variables \a vs.
 template<class T> Bool is_additive_in(const Vector<Expression<T>>& e, const Set<Variable<T>>& vs);
 
+//! \brief Check the ordering of two expressions \a e1 and \a e2, by identifying whether \a e1 precedes \a e2.
+template<class T> Bool before(Expression<T> const& e1, Expression<T> const& e2);
+
 //! \brief Simplify the expression \a e.
 template<class T> Expression<T> simplify(const Expression<T>& e);
 template<class T> Void eliminate_common_subexpressions(Vector<Expression<T>>& e);
@@ -176,6 +179,11 @@ template<class T> Void eliminate_common_subexpressions(Expression<T>& e);
 
 //! \brief Tests whether two expressions are identical.
 template<class T> Bool identical(const Expression<T>& e1, const Expression<T>& e2);
+
+//! \brief Count the number of nodes in the expression \a e.
+template<class T> Nat count_nodes(const Expression<T>& e);
+//! \brief Count the number of distinct (i.e., having different raw pointer) nodes in the expression \a e.
+template<class T> Nat count_distinct_nodes(const Expression<T>& e);
 
 //! \brief Returns true if the expressions are mutual negations.
 //!

--- a/source/symbolic/expression.hpp
+++ b/source/symbolic/expression.hpp
@@ -161,13 +161,13 @@ template<class T> Bool is_variable(const Expression<T>& e, const Identifier& vn)
 template<class T> Bool is_variable(const Expression<T>& e, const Variable<T>& v);
 
 //! \brief Returns \a true if the expression \a e is syntactically constant in the variables \a vs.
-Bool is_constant_in(const Expression<Real>& e, const Set<Variable<Real>>& vs);
+template<class T> Bool is_constant_in(const Expression<T>& e, const Set<Variable<T>>& vs);
 //! \brief Returns \a true if the expression \a e is syntactically affine in the variables \a vs.
-Bool is_affine_in(const Expression<Real>& e, const Set<Variable<Real>>& vs);
+template<class T> Bool is_affine_in(const Expression<T>& e, const Set<Variable<T>>& vs);
 //! \brief Returns \a true if the vector expression \a e is syntactically affine in the variables \a vs.
-Bool is_affine_in(const Vector<Expression<Real>>& e, const Set<Variable<Real>>& vs);
-//! \brief Returns \a true if the vector expression \a e is syntactically additive in the variables \a vs.
-Bool is_additive_in(const Vector<Expression<Real>>& e, const Set<Variable<Real>>& vs);
+template<class T> Bool is_affine_in(const Vector<Expression<T>>& e, const Set<Variable<T>>& vs);
+//! \brief Returns \a true if the vector expression \a e is syntactically additive (possibly with multipliers) in the variables \a vs.
+template<class T> Bool is_additive_in(const Vector<Expression<T>>& e, const Set<Variable<T>>& vs);
 
 //! \brief Simplify the expression \a e.
 template<class T> Expression<T> simplify(const Expression<T>& e);
@@ -216,8 +216,6 @@ Expression<Real> make_expression(const ScalarMultivariateFunction<EffectiveTag>&
 Expression<Real> make_expression(const Formula<Real>& f, const Space<Real>& s);
 
 //@}
-
-
 
 
 } // namespace Ariadne

--- a/tests/function/test_taylor_function.cpp
+++ b/tests/function/test_taylor_function.cpp
@@ -47,6 +47,7 @@ using namespace std;
 using namespace Ariadne;
 
 extern template Ariadne::Nat Ariadne::Error<Ariadne::FloatDP>::output_places;
+extern template Ariadne::Nat Ariadne::Error<Ariadne::FloatMP>::output_places;
 
 inline Vector<Real> e(Nat n, Nat i) { return Vector<Real>::unit(n,i); }
 inline Polynomial<FloatDP> p(Nat n, Nat j) { return Polynomial<FloatDP>::variable(n,j); }

--- a/tests/function/test_taylor_model.cpp
+++ b/tests/function/test_taylor_model.cpp
@@ -39,6 +39,7 @@
 using std::cout; using std::cerr; using std::endl;
 using namespace Ariadne;
 
+extern template Ariadne::Nat Ariadne::Error<Ariadne::FloatDP>::output_places;
 extern template Ariadne::Nat Ariadne::Error<Ariadne::FloatMP>::output_places;
 
 inline Dyadic operator"" _exd (long double x) { return Dyadic(x); }

--- a/tests/symbolic/test_expression.cpp
+++ b/tests/symbolic/test_expression.cpp
@@ -179,9 +179,9 @@ class TestExpression {
         ARIADNE_TEST_ASSERT(is_additive_in(Vector<RealExpression>({x+u2,y+u1}),{u1,u2}));
         ARIADNE_TEST_ASSERT(is_additive_in(Vector<RealExpression>({x+u1,y}),{u1}));
         ARIADNE_TEST_ASSERT(is_additive_in(Vector<RealExpression>({x,y+u1}),{u1}));
+        ARIADNE_TEST_ASSERT(is_additive_in(Vector<RealExpression>({x,y+2*u1}),{u1}));
+        ARIADNE_TEST_ASSERT(is_additive_in(Vector<RealExpression>({x+u1,y+2*u2}),{u1,u2}));
         ARIADNE_TEST_ASSERT(not is_additive_in(Vector<RealExpression>({x+u1,y+u1}),{u1}));
-        ARIADNE_TEST_ASSERT(not is_additive_in(Vector<RealExpression>({x,y+2*u1}),{u1}));
-        ARIADNE_TEST_ASSERT(not is_additive_in(Vector<RealExpression>({x+u1,y+2*u2}),{u1,u2}));
         ARIADNE_TEST_ASSERT(not is_additive_in(Vector<RealExpression>({x*u1,y+u2}),{u1,u2}));
         ARIADNE_TEST_ASSERT(not is_additive_in(Vector<RealExpression>({x+u1,y+sqr(u2)}),{u1,u2}));
     }

--- a/tests/symbolic/test_expression.cpp
+++ b/tests/symbolic/test_expression.cpp
@@ -132,6 +132,33 @@ class TestExpression {
         ARIADNE_TEST_ASSERT(identical(simplification,-u*y+2));
     }
 
+    Void test_ordering() {
+        RealExpression expr1_1 = x; RealExpression expr1_2 = y;
+        ARIADNE_TEST_ASSERT(before(expr1_1,expr1_2));
+        RealExpression expr2_1 = x; RealExpression expr2_2 = x;
+        ARIADNE_TEST_ASSERT(not before(expr2_1,expr2_2));
+        RealExpression expr3_1 = 1; RealExpression expr3_2 = 2;
+        ARIADNE_TEST_ASSERT(before(expr3_1,expr3_2));
+        RealExpression expr4_1 = 5; RealExpression expr4_2 = 2;
+        ARIADNE_TEST_ASSERT(not before(expr4_1,expr4_2));
+        RealExpression expr5_1 = pow(x,2); RealExpression expr5_2 = pow(x,3);
+        ARIADNE_TEST_ASSERT(before(expr5_1,expr5_2));
+        RealExpression expr6_1 = pow(y,2); RealExpression expr6_2 = pow(x,3);
+        ARIADNE_TEST_ASSERT(before(expr6_1,expr6_2));
+        RealExpression expr7_1 = pow(x,2); RealExpression expr7_2 = pow(x,3);
+        ARIADNE_TEST_ASSERT(before(expr7_1,expr7_2));
+        RealExpression expr8_1 = sin(y); RealExpression expr8_2 = sin(x);
+        ARIADNE_TEST_ASSERT(not before(expr8_1,expr8_2));
+        RealExpression expr9_1 = sqrt(x); RealExpression expr9_2 = sin(y);
+        ARIADNE_TEST_ASSERT(before(expr9_1,expr9_2));
+        RealExpression expr10_1 = x+y; RealExpression expr10_2 = y+x;
+        ARIADNE_TEST_ASSERT(before(expr10_1,expr10_2));
+        RealExpression expr11_1 = x+y; RealExpression expr11_2 = x+x;
+        ARIADNE_TEST_ASSERT(not before(expr11_1,expr11_2));
+        RealExpression expr12_1 = log(x); RealExpression expr12_2 = rec(x);
+        ARIADNE_TEST_ASSERT(not before(expr12_1,expr12_2));
+    }
+
     Void test_count_nodes() {
         RealExpression expr1 = x;
         ARIADNE_TEST_EQUAL(count_nodes(expr1),1);
@@ -175,36 +202,57 @@ class TestExpression {
         ARIADNE_TEST_EQUAL(count_distinct_nodes(expr9),5);
     }
 
-    Void test_ordering() {
-        RealExpression expr1_1 = x; RealExpression expr1_2 = y;
-        ARIADNE_TEST_ASSERT(before(expr1_1,expr1_2));
-        RealExpression expr2_1 = x; RealExpression expr2_2 = x;
-        ARIADNE_TEST_ASSERT(not before(expr2_1,expr2_2));
-        RealExpression expr3_1 = 1; RealExpression expr3_2 = 2;
-        ARIADNE_TEST_ASSERT(before(expr3_1,expr3_2));
-        RealExpression expr4_1 = 5; RealExpression expr4_2 = 2;
-        ARIADNE_TEST_ASSERT(not before(expr4_1,expr4_2));
-        RealExpression expr5_1 = pow(x,2); RealExpression expr5_2 = pow(x,3);
-        ARIADNE_TEST_ASSERT(before(expr5_1,expr5_2));
-        RealExpression expr6_1 = pow(y,2); RealExpression expr6_2 = pow(x,3);
-        ARIADNE_TEST_ASSERT(before(expr6_1,expr6_2));
-        RealExpression expr7_1 = pow(x,2); RealExpression expr7_2 = pow(x,3);
-        ARIADNE_TEST_ASSERT(before(expr7_1,expr7_2));
-        RealExpression expr8_1 = sin(y); RealExpression expr8_2 = sin(x);
-        ARIADNE_TEST_ASSERT(not before(expr8_1,expr8_2));
-        RealExpression expr9_1 = sqrt(x); RealExpression expr9_2 = sin(y);
-        ARIADNE_TEST_ASSERT(before(expr9_1,expr9_2));
-        RealExpression expr10_1 = x+y; RealExpression expr10_2 = y+x;
-        ARIADNE_TEST_ASSERT(before(expr10_1,expr10_2));
-        RealExpression expr11_1 = x+y; RealExpression expr11_2 = x+x;
-        ARIADNE_TEST_ASSERT(not before(expr11_1,expr11_2));
-        RealExpression expr12_1 = log(x); RealExpression expr12_2 = rec(x);
-        ARIADNE_TEST_ASSERT(not before(expr12_1,expr12_2));
+    Void test_count_distinct_node_ptrs() {
+        RealExpression expr1 = x;
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr1),1);
+        RealExpression expr2 = x*exp(x);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr2),4);
+        RealExpression expr3 = x*x;
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr3),3);
+        RealExpression one = 1;
+        RealExpression expr4 = one+cos(one);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr4),3);
+        RealExpression expr5 = x*y+sqr(x*y);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr5),8);
+        RealExpression expr6 = pow(x,2)*pow(x,2);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr6),5);
+        RealExpression expr7 = pow(y,2)+y*y;
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr7),6);
+        RealExpression expr8 = pow(x+cos(y),2)+cos(y);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr8),8);
+        RealExpression expr9 = x+cos(x)+pow(cos(x),2);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr9),8);
     }
 
     Void test_eliminate_common_subexpressions() {
-
-
+        RealExpression expr1 = x;
+        eliminate_common_subexpressions(expr1);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr1),1);
+        RealExpression expr2 = x*exp(x);
+        eliminate_common_subexpressions(expr2);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr2),3);
+        RealExpression expr3 = x*x;
+        eliminate_common_subexpressions(expr3);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr3),2);
+        RealExpression one = 1;
+        RealExpression expr4 = one+cos(one);
+        eliminate_common_subexpressions(expr4);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr4),3);
+        RealExpression expr5 = x*y+sqr(x*y);
+        eliminate_common_subexpressions(expr5);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr5),5);
+        RealExpression expr6 = pow(x,2)*pow(x,2);
+        eliminate_common_subexpressions(expr6);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr6),3);
+        RealExpression expr7 = pow(y,2)+y*y;
+        eliminate_common_subexpressions(expr7);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr7),4);
+        RealExpression expr8 = pow(x+cos(y),2)+cos(y);
+        eliminate_common_subexpressions(expr8);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr8),6);
+        RealExpression expr9 = x+cos(x)+pow(cos(x),2);
+        eliminate_common_subexpressions(expr9);
+        ARIADNE_TEST_EQUAL(count_distinct_node_ptrs(expr9),5);
     }
 
     Void test_substitute() {
@@ -316,9 +364,10 @@ class TestExpression {
         test_parameters();
         test_derivative();
         test_simplify();
+        test_ordering();
         test_count_nodes();
         test_count_distinct_nodes();
-        test_ordering();
+        test_count_distinct_node_ptrs();
         test_eliminate_common_subexpressions();
         test_substitute();
         test_scalar_properties();

--- a/tests/symbolic/test_expression.cpp
+++ b/tests/symbolic/test_expression.cpp
@@ -132,6 +132,81 @@ class TestExpression {
         ARIADNE_TEST_ASSERT(identical(simplification,-u*y+2));
     }
 
+    Void test_count_nodes() {
+        RealExpression expr1 = x;
+        ARIADNE_TEST_EQUAL(count_nodes(expr1),1);
+        RealExpression expr2 = 1;
+        ARIADNE_TEST_EQUAL(count_nodes(expr2),1);
+        RealExpression expr3 = 2*x;
+        ARIADNE_TEST_EQUAL(count_nodes(expr3),3);
+        RealExpression expr4 = x+y;
+        ARIADNE_TEST_EQUAL(count_nodes(expr4),3);
+        RealExpression expr5 = x+sqr(y);
+        ARIADNE_TEST_EQUAL(count_nodes(expr5),4);
+        RealExpression expr6 = sin(y);
+        ARIADNE_TEST_EQUAL(count_nodes(expr6),2);
+        RealExpression expr7 = pow(y,2);
+        ARIADNE_TEST_EQUAL(count_nodes(expr7),2);
+        RealExpression expr8 = pow(x+cos(y),2)+cos(y);
+        ARIADNE_TEST_EQUAL(count_nodes(expr8),8);
+        RealExpression expr9 = x+cos(x)+pow(cos(x),2);
+        ARIADNE_TEST_EQUAL(count_nodes(expr9),8);
+    }
+
+    Void test_count_distinct_nodes() {
+        RealExpression expr1 = x;
+        ARIADNE_TEST_EQUAL(count_distinct_nodes(expr1),1);
+        RealExpression expr2 = x*exp(x);
+        ARIADNE_TEST_EQUAL(count_distinct_nodes(expr2),3);
+        RealExpression expr3 = x*x;
+        ARIADNE_TEST_EQUAL(count_distinct_nodes(expr3),2);
+        RealExpression one = 1;
+        RealExpression expr4 = one+cos(one);
+        ARIADNE_TEST_EQUAL(count_distinct_nodes(expr4),3);
+        RealExpression expr5 = x*y+sqr(x*y);
+        ARIADNE_TEST_EQUAL(count_distinct_nodes(expr5),5);
+        RealExpression expr6 = pow(x,2)*pow(x,2);
+        ARIADNE_TEST_EQUAL(count_distinct_nodes(expr6),3);
+        RealExpression expr7 = pow(y,2)+y*y;
+        ARIADNE_TEST_EQUAL(count_distinct_nodes(expr7),4);
+        RealExpression expr8 = pow(x+cos(y),2)+cos(y);
+        ARIADNE_TEST_EQUAL(count_distinct_nodes(expr8),6);
+        RealExpression expr9 = x+cos(x)+pow(cos(x),2);
+        ARIADNE_TEST_EQUAL(count_distinct_nodes(expr9),5);
+    }
+
+    Void test_ordering() {
+        RealExpression expr1_1 = x; RealExpression expr1_2 = y;
+        ARIADNE_TEST_ASSERT(before(expr1_1,expr1_2));
+        RealExpression expr2_1 = x; RealExpression expr2_2 = x;
+        ARIADNE_TEST_ASSERT(not before(expr2_1,expr2_2));
+        RealExpression expr3_1 = 1; RealExpression expr3_2 = 2;
+        ARIADNE_TEST_ASSERT(before(expr3_1,expr3_2));
+        RealExpression expr4_1 = 5; RealExpression expr4_2 = 2;
+        ARIADNE_TEST_ASSERT(not before(expr4_1,expr4_2));
+        RealExpression expr5_1 = pow(x,2); RealExpression expr5_2 = pow(x,3);
+        ARIADNE_TEST_ASSERT(before(expr5_1,expr5_2));
+        RealExpression expr6_1 = pow(y,2); RealExpression expr6_2 = pow(x,3);
+        ARIADNE_TEST_ASSERT(before(expr6_1,expr6_2));
+        RealExpression expr7_1 = pow(x,2); RealExpression expr7_2 = pow(x,3);
+        ARIADNE_TEST_ASSERT(before(expr7_1,expr7_2));
+        RealExpression expr8_1 = sin(y); RealExpression expr8_2 = sin(x);
+        ARIADNE_TEST_ASSERT(not before(expr8_1,expr8_2));
+        RealExpression expr9_1 = sqrt(x); RealExpression expr9_2 = sin(y);
+        ARIADNE_TEST_ASSERT(before(expr9_1,expr9_2));
+        RealExpression expr10_1 = x+y; RealExpression expr10_2 = y+x;
+        ARIADNE_TEST_ASSERT(before(expr10_1,expr10_2));
+        RealExpression expr11_1 = x+y; RealExpression expr11_2 = x+x;
+        ARIADNE_TEST_ASSERT(not before(expr11_1,expr11_2));
+        RealExpression expr12_1 = log(x); RealExpression expr12_2 = rec(x);
+        ARIADNE_TEST_ASSERT(not before(expr12_1,expr12_2));
+    }
+
+    Void test_eliminate_common_subexpressions() {
+
+
+    }
+
     Void test_substitute() {
 
         RealVariable u1("u1"), u2("u2");
@@ -241,6 +316,10 @@ class TestExpression {
         test_parameters();
         test_derivative();
         test_simplify();
+        test_count_nodes();
+        test_count_distinct_nodes();
+        test_ordering();
+        test_eliminate_common_subexpressions();
         test_substitute();
         test_scalar_properties();
         test_vector_properties();


### PR DESCRIPTION
Adds node counting methods: a) total number b) number of distinct nodes c) number of distinct node pointers.

Also adds tests for these function and the `eliminate_common_subexpressions` function.

Finally, a minor cleanup to generalise is_additive_in to additivity with constant multipliers, and to address a missed warning on ::output_places.