### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,96 @@
+---
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Right
+AlignOperands: AlignAfterOperator
+UseTab: Never
+TabWidth: 4
+SpacesInParensOptions:
+  InConditionalStatements: false
+  InCStyleCasts: false
+  InEmptyParentheses: false
+  Other: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+ContinuationIndentWidth: 4
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterEnum: false
+  AfterControlStatement: Never
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: AfterComma
+CompactNamespaces: false
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: Always
+FixNamespaceComments: true
+IncludeBlocks: Regroup
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+InsertNewlineAtEOF: true
+KeepEmptyLinesAtEOF: true
+Language: Cpp
+NamespaceIndentation: None
+PointerAlignment: Left
+QualifierAlignment: Left
+ReferenceAlignment: Pointer
+SortUsingDeclarations: Lexicographic
+SortIncludes: CaseInsensitive
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeParensOptions:
+  AfterControlStatements: false
+  AfterForeachMacros: false
+  AfterFunctionDeclarationName: false
+  AfterFunctionDefinitionName: false
+  AfterIfMacros: false
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesInParens: Never
+SpacesInContainerLiterals: false
+SpacesInAngles: Never
+SpacesInSquareBrackets: false
+Standard: Auto
+ColumnLimit: 0
+KeepEmptyLinesAtTheStartOfBlocks: false
+IncludeCategories:
+  - Regex: <([A-Za-z0-9\Q/-_\E])+>
+    Priority: 1
+  - Regex: <(catch2|boost)\/
+    Priority: 2
+  - Regex: <([A-Za-z0-9.\Q/-_\E])+>
+    Priority: 3
+  - Regex: '"([A-Za-z0-9.\Q/-_\E])+"'
+    Priority: 4


### PR DESCRIPTION
A quality-of-life change to allow supported editors to format code using project conventions, without any additional configuring.

The indentation rules in the coding guidelines are included. Everything else is included so that new code *mostly* follows existing styles within this project.